### PR TITLE
feature/clase-69

### DIFF
--- a/src/main/java/com/bolsadeideas/springboot/form/app/controllers/FormController.java
+++ b/src/main/java/com/bolsadeideas/springboot/form/app/controllers/FormController.java
@@ -32,7 +32,7 @@ public class FormController {
 		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 		dateFormat.setLenient(false);
 
-		binder.registerCustomEditor(Date.class, new CustomDateEditor(dateFormat, false));
+		binder.registerCustomEditor(Date.class, "fechaNacimiento", new CustomDateEditor(dateFormat, true));
 		binder.addValidators(validador);
 	}
 


### PR DESCRIPTION
En el método initBinder de la clase FormController se especifica el
campo al que aplicar el CustomEditor. La nueva instancia de
CustomDateEditor se genera ahora con el segundo parámetro a true, esto
hace que el validador del formato de fecha no lance excepción si no se
introduce la fecha y sea sea la etiqueta @NotNull quien lance la
excepción.